### PR TITLE
feat: enrich Falco alerts with AIB asset graph context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,3 +101,9 @@ ANTHROPIC_API_KEY=your-api-key
 # Ollama (local - for privacy)
 # OLLAMA_URL=http://localhost:11434
 # OLLAMA_MODEL=qwen2.5:14b
+
+# ==================== AIB Integration (Optional) ====================
+# Assets in a Box — enriches Falco alerts with asset metadata, blast radius,
+# and audit findings before LLM analysis. Leave blank to disable.
+# AIB_BASE_URL=http://aib:8080
+# AIB_API_TOKEN=your-aib-api-token

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -178,13 +178,20 @@ Analysis results are cached to avoid repeated LLM calls for the same event. Cach
 - Cache keys are normalized: timestamps, numeric IDs, IPs, and container IDs are stripped so similar events share a cache key
 - A `dedup_count` field tracks how many times the same alert was requested
 
+## AIB Integration (Asset Context)
+
+When [Assets in a Box (AIB)](../docs/aib-integration.md) is configured, alerts are enriched with asset metadata, blast radius, and pre-existing audit findings *before* reaching the LLM. This lets the model reason about real-world impact rather than just the raw event.
+
+Set `AIB_BASE_URL` in your `.env` to enable it — see **[docs/aib-integration.md](../docs/aib-integration.md)** for the full setup guide, data flow, and example output.
+
 ## How It Works
 
 1. **Alert Ingested** → Falco detects suspicious activity
-2. **Obfuscation** → Sensitive data replaced with tokens
-3. **LLM Analysis** → Security-focused prompt analyzes the alert
-4. **Enrichment** → Response parsed and attached to alert
-5. **Storage** → Enriched alert stored in Loki with analysis labels
+2. **AIB Enrichment** *(optional)* → Asset metadata, blast radius, and audit findings fetched
+3. **Obfuscation** → Sensitive data replaced with tokens
+4. **LLM Analysis** → Security-focused prompt analyzes the alert (with asset context if available)
+5. **Enrichment** → Response parsed and attached to alert
+6. **Storage** → Enriched alert stored in Loki with analysis labels
 
 ## Example Output
 

--- a/analysis/aib_bridge.py
+++ b/analysis/aib_bridge.py
@@ -1,0 +1,180 @@
+"""
+AIB (Assets in a Box) bridge for SIB alert enrichment.
+
+Fetches asset metadata, blast radius, and audit findings from the AIB graph API
+to enrich Falco security alerts before LLM analysis.
+
+Asset node ID format: source:type:identifier
+  - k8s:pod:namespace/name
+  - k8s:node:nodename
+  - vm:host:hostname
+"""
+
+import time
+import logging
+import requests
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class AIBClient:
+    """Client for the AIB REST API with TTL caching."""
+
+    def __init__(self, base_url: str, api_token: Optional[str] = None,
+                 ttl: int = 300, timeout: int = 5):
+        self.base_url = base_url.rstrip('/')
+        self.api_token = api_token
+        self.ttl = ttl
+        self.timeout = timeout
+        self._cache: dict = {}
+
+    def _headers(self) -> dict:
+        h = {'Accept': 'application/json'}
+        if self.api_token:
+            h['Authorization'] = f'Bearer {self.api_token}'
+        return h
+
+    def _get(self, path: str) -> Optional[dict]:
+        """Cached GET. Returns None on any error (including 404)."""
+        now = time.monotonic()
+        if path in self._cache:
+            ts, data = self._cache[path]
+            if now - ts < self.ttl:
+                return data
+
+        try:
+            r = requests.get(
+                f"{self.base_url}{path}",
+                headers=self._headers(),
+                timeout=self.timeout,
+            )
+            if r.status_code == 404:
+                self._cache[path] = (now, None)
+                return None
+            r.raise_for_status()
+            data = r.json()
+            self._cache[path] = (now, data)
+            return data
+        except Exception as e:
+            logger.debug("AIB request failed %s: %s", path, e)
+            return None
+
+    def get_node(self, node_id: str) -> Optional[dict]:
+        return self._get(f"/api/v1/graph/nodes/{node_id}")
+
+    def get_blast_radius(self, node_id: str) -> Optional[dict]:
+        return self._get(f"/api/v1/impact/{node_id}")
+
+    def get_audit_findings(self, node_id: str) -> list:
+        data = self._get(f"/api/v1/graph/analysis/audit?node_id={node_id}")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return data.get('findings') or data.get('results') or []
+        return []
+
+    def enrich_alert(self, alert: dict) -> dict:
+        """
+        Derive AIB context from Falco alert fields.
+
+        Tries k8s pod lookup first (container.name + namespace), then VM/host
+        lookup (host.hostname). All lookups are best-effort — returns an empty
+        context dict if the asset isn't in AIB or AIB is unreachable.
+
+        Returns:
+            {
+                'node_id':        str | None,
+                'node':           dict | None,   # raw AIB node metadata
+                'blast_radius':   dict | None,
+                'audit_findings': list,          # capped at 5 entries
+            }
+        """
+        output_fields = alert.get('output_fields', {})
+        labels = alert.get('_labels', {})
+
+        container_name = (
+            output_fields.get('container.name')
+            or labels.get('container_name', '')
+        )
+        namespace = (
+            output_fields.get('kubernetes.namespace.name')
+            or labels.get('namespace', 'default')
+        )
+        hostname = (
+            output_fields.get('host.hostname')
+            or output_fields.get('hostname')
+            or labels.get('hostname', '')
+        )
+
+        node = None
+        node_id = None
+
+        if container_name and container_name not in ('', 'host', '<NA>'):
+            node_id = f"k8s:pod:{namespace}/{container_name}"
+            node = self.get_node(node_id)
+
+        if node is None and hostname:
+            for candidate in (f"vm:host:{hostname}", f"k8s:node:{hostname}"):
+                node = self.get_node(candidate)
+                if node:
+                    node_id = candidate
+                    break
+
+        blast_radius = None
+        audit_findings: list = []
+
+        if node_id:
+            blast_radius = self.get_blast_radius(node_id)
+            audit_findings = self.get_audit_findings(node_id)[:5]
+
+        return {
+            'node_id': node_id,
+            'node': node,
+            'blast_radius': blast_radius,
+            'audit_findings': audit_findings,
+        }
+
+
+def format_aib_context(ctx: dict) -> str:
+    """
+    Render AIB enrichment context as a prompt section.
+
+    Returns an empty string if no useful context is available so the
+    caller can safely concatenate without branching.
+    """
+    if not ctx or not ctx.get('node'):
+        return ''
+
+    node = ctx['node']
+    node_id = ctx.get('node_id', 'unknown')
+
+    lines = ['\n\n**Asset Context (AIB graph):**']
+    lines.append(f'- Asset ID: `{node_id}`')
+
+    # Surface any structured metadata the AIB node carries
+    meta = node.get('metadata') or node.get('properties') or node.get('labels') or {}
+    for key in ('environment', 'team', 'criticality', 'owner', 'service'):
+        val = meta.get(key)
+        if val:
+            lines.append(f'- {key.title()}: {val}')
+
+    # Blast radius
+    br = ctx.get('blast_radius')
+    if br:
+        affected = br.get('affected_nodes') or br.get('nodes') or []
+        if affected:
+            lines.append(f'- Blast radius: {len(affected)} downstream assets')
+            for n in affected[:3]:
+                nid = n.get('id') or n.get('node_id') or str(n)
+                lines.append(f'  - {nid}')
+
+    # Pre-existing audit findings
+    findings = ctx.get('audit_findings') or []
+    if findings:
+        lines.append(f'- Pre-existing audit findings ({len(findings)}):')
+        for f in findings:
+            title = f.get('title') or f.get('finding') or f.get('message') or str(f) if isinstance(f, dict) else str(f)
+            lines.append(f'  - {title}')
+
+    return '\n'.join(lines)

--- a/analysis/analyzer.py
+++ b/analysis/analyzer.py
@@ -273,7 +273,7 @@ class AnthropicProvider(LLMProvider):
 
 class AlertAnalyzer:
     """Main analyzer class that coordinates obfuscation and LLM analysis."""
-    
+
     def __init__(self, config: dict):
         self.config = config
         self.backend = config.get('storage', {}).get('backend', 'loki')
@@ -286,7 +286,23 @@ class AlertAnalyzer:
             self.backend = 'loki'
         self.obfuscation_level = config.get('analysis', {}).get('obfuscation_level', 'standard')
         self.provider = self._create_provider()
+        self.aib_client = self._create_aib_client()
     
+    def _create_aib_client(self):
+        """Create AIB client if configured. Returns None if AIB is not set up."""
+        aib_cfg = self.config.get('aib', {})
+        base_url = aib_cfg.get('url') or os.environ.get('AIB_BASE_URL', '')
+        if not base_url:
+            return None
+        try:
+            from aib_bridge import AIBClient
+            api_token = aib_cfg.get('api_token') or os.environ.get('AIB_API_TOKEN')
+            ttl = int(aib_cfg.get('cache_ttl', 300))
+            return AIBClient(base_url, api_token=api_token, ttl=ttl)
+        except ImportError:
+            print("aib_bridge not found — AIB enrichment disabled", file=sys.stderr)
+            return None
+
     def _create_provider(self) -> LLMProvider:
         """Create the configured LLM provider."""
         analysis_config = self.config.get('analysis', {})
@@ -346,7 +362,16 @@ class AlertAnalyzer:
         """Analyze a single alert."""
         # Obfuscate the alert
         obfuscated, mapping = obfuscate_alert(alert, self.obfuscation_level)
-        
+
+        # Enrich with AIB asset context (graceful — alert still analyzed without it)
+        aib_context: dict = {}
+        if self.aib_client:
+            try:
+                from aib_bridge import format_aib_context
+                aib_context = self.aib_client.enrich_alert(alert)
+            except Exception as e:
+                print(f"AIB enrichment skipped: {e}", file=sys.stderr)
+
         # Build the prompt
         labels = alert.get('_labels', {})
         user_prompt = USER_PROMPT_TEMPLATE.format(
@@ -360,18 +385,26 @@ class AlertAnalyzer:
             process=obfuscated.get('output_fields', {}).get('proc.name', 'N/A'),
             parent_process=obfuscated.get('output_fields', {}).get('proc.pname', 'N/A'),
         )
-        
+
+        # Append AIB context to prompt if available
+        if aib_context:
+            from aib_bridge import format_aib_context
+            aib_section = format_aib_context(aib_context)
+            if aib_section:
+                user_prompt += aib_section
+
         if dry_run:
             return {
                 'obfuscated_prompt': user_prompt,
                 'obfuscation_mapping': mapping,
+                'aib_context': aib_context,
                 'note': 'Dry run - no LLM call made'
             }
-        
+
         # Get quick MITRE mapping if available
         rule_name = labels.get('rule', alert.get('rule', ''))
         quick_mitre = MITRE_MAPPING.get(rule_name, None)
-        
+
         # Call LLM
         try:
             analysis = self.provider.analyze(SYSTEM_PROMPT, user_prompt)
@@ -380,11 +413,12 @@ class AlertAnalyzer:
                 'error': str(e),
                 'fallback_mitre': quick_mitre
             }
-        
+
         return {
             'original_alert': alert,
             'obfuscated_alert': obfuscated,
             'obfuscation_mapping': mapping,
+            'aib_context': aib_context,
             'analysis': analysis
         }
     

--- a/analysis/api.py
+++ b/analysis/api.py
@@ -363,6 +363,44 @@ ANALYSIS_TEMPLATE = """
             <p>{{ analysis.summary or 'No summary available.' }}</p>
         </div>
         
+        {% if aib_context and aib_context.node %}
+        <h2>🗺️ Asset Context (AIB)</h2>
+        <div class="card">
+            <div class="section">
+                <div class="label">Asset ID</div>
+                <div class="value" style="font-family: monospace;">{{ aib_context.node_id }}</div>
+            </div>
+            {% set meta = aib_context.node.get('metadata') or aib_context.node.get('properties') or {} %}
+            {% for key in ['environment', 'team', 'criticality', 'owner', 'service'] %}
+            {% if meta.get(key) %}
+            <div class="section">
+                <div class="label">{{ key|title }}</div>
+                <div class="value">{{ meta[key] }}</div>
+            </div>
+            {% endif %}
+            {% endfor %}
+            {% if aib_context.blast_radius %}
+            {% set affected = aib_context.blast_radius.get('affected_nodes') or aib_context.blast_radius.get('nodes') or [] %}
+            {% if affected %}
+            <div class="section">
+                <div class="label">Blast Radius</div>
+                <div class="value">{{ affected|length }} downstream assets</div>
+            </div>
+            {% endif %}
+            {% endif %}
+            {% if aib_context.audit_findings %}
+            <div class="section">
+                <div class="label">Pre-existing Audit Findings</div>
+                <ul class="mitigation-list">
+                    {% for f in aib_context.audit_findings %}
+                    <li>{{ f.get('title') or f.get('finding') or f if f is mapping else f }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+        </div>
+        {% endif %}
+
         {% if show_mapping and obfuscation_mapping %}
         <h2>🔐 Obfuscation Mapping</h2>
         <div class="card">
@@ -465,6 +503,7 @@ def save_to_cache(cache_key: str, result: dict, original_output: str, rule: str,
         'analysis': result.get('analysis', {}),
         'obfuscated_output': result.get('obfuscated_alert', {}).get('output', '') if isinstance(result.get('obfuscated_alert'), dict) else '',
         'obfuscation_mapping': result.get('obfuscation_mapping', {}),
+        'aib_context': result.get('aib_context', {}),
         'dedup_count': 1,
         'last_seen': datetime.now().isoformat(),
     }
@@ -620,7 +659,8 @@ def analyze_api():
         return jsonify({
             'success': True,
             'analysis': result.get('analysis', {}),
-            'obfuscation_mapping': result.get('obfuscation_mapping', {})
+            'obfuscation_mapping': result.get('obfuscation_mapping', {}),
+            'aib_context': result.get('aib_context', {}),
         })
         
     except Exception as e:
@@ -649,13 +689,14 @@ def analyze_page():
         show_mapping = request.args.get('show_mapping', 'false').lower() == 'true'
         
         if not output:
-            return render_template_string(ANALYSIS_TEMPLATE, 
+            return render_template_string(ANALYSIS_TEMPLATE,
                 error="No alert output provided. Use ?output=... parameter.",
                 analysis={},
                 original_output='',
                 obfuscated_output='',
                 severity_class='',
                 obfuscation_mapping={},
+                aib_context={},
                 show_mapping=False,
                 timestamp=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
                 cached=False
@@ -679,6 +720,7 @@ def analyze_page():
                 obfuscated_output=cached_result.get('obfuscated_output', ''),
                 severity_class=severity_class,
                 obfuscation_mapping=cached_result.get('obfuscation_mapping', {}),
+                aib_context=cached_result.get('aib_context', {}),
                 show_mapping=show_mapping,
                 timestamp=cached_result.get('timestamp', 'cached'),
                 cached=True
@@ -726,11 +768,12 @@ def analyze_page():
             obfuscated_output=obfuscated_output,
             severity_class=severity_class,
             obfuscation_mapping=result.get('obfuscation_mapping', {}),
+            aib_context=result.get('aib_context', {}),
             show_mapping=show_mapping,
             timestamp=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             cached=False
         )
-        
+
     except Exception as e:
         logger.exception("Analysis page failed")
         return render_template_string(ANALYSIS_TEMPLATE,
@@ -740,6 +783,7 @@ def analyze_page():
             obfuscated_output='',
             severity_class='',
             obfuscation_mapping={},
+            aib_context={},
             show_mapping=False,
             timestamp=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             cached=False
@@ -813,6 +857,7 @@ def history_detail(cache_key: str):
         obfuscated_output=cached.get('obfuscated_output', ''),
         severity_class=severity_class,
         obfuscation_mapping=cached.get('obfuscation_mapping', {}),
+        aib_context=cached.get('aib_context', {}),
         show_mapping=False,
         timestamp=cached.get('timestamp', 'cached'),
         cached=True

--- a/analysis/config.yaml
+++ b/analysis/config.yaml
@@ -21,6 +21,14 @@ analysis:
     api_key: ${OPENAI_API_KEY}
     model: ${OPENAI_MODEL:-gpt-4o}
 
+# AIB (Assets in a Box) integration - optional
+# When configured, Falco alerts are enriched with asset metadata, blast radius,
+# and audit findings from the AIB graph before LLM analysis.
+aib:
+  url: ${AIB_BASE_URL:-}
+  api_token: ${AIB_API_TOKEN:-}
+  cache_ttl: 300  # seconds
+
 # Storage backend: loki or vm (auto-detected from STACK env var)
 storage:
   backend: ${STACK:-loki}

--- a/docs/aib-integration.md
+++ b/docs/aib-integration.md
@@ -1,0 +1,190 @@
+# AIB Integration — Asset-Enriched Alert Analysis
+
+> **Optional Feature**: Requires [Assets in a Box (AIB)](https://github.com/matijazezelj/aib) running and accessible from the SIB analysis container.
+
+## What Is AIB?
+
+Assets in a Box (AIB) is a graph-based asset inventory. It models your infrastructure as a graph of nodes (Kubernetes pods, VMs, hosts, services) with relationships between them — ownership, network adjacency, dependency chains.
+
+Each node carries:
+- **Metadata** — environment, team, owner, criticality, service name
+- **Blast radius** — which downstream assets are reachable if this node is compromised
+- **Audit findings** — pre-existing security findings from previous scans
+
+## What the Integration Does
+
+Without AIB, SIB analyzes Falco alerts purely from the event payload — process name, syscall, file path, priority. The LLM has no idea *what* the affected asset is, who owns it, or what it connects to.
+
+With AIB, before the alert reaches the LLM:
+
+1. **Asset lookup** — SIB extracts the container name + namespace (for Kubernetes) or hostname (for VMs) from the Falco alert and resolves the corresponding AIB node
+2. **Blast radius fetch** — how many downstream assets are reachable if this node is compromised
+3. **Audit findings fetch** — any pre-existing findings on this asset (misconfigurations, CVEs, compliance gaps)
+4. **Prompt injection** — all of this is appended to the LLM prompt as structured context
+
+The result: the LLM can reason about *actual impact*, not just the raw event. A `Read sensitive file` alert on an internet-facing payment service that has 12 downstream dependencies hits differently than the same alert on an internal dev sandbox.
+
+## Data Flow
+
+```
+Falco alert
+    │
+    ▼
+AlertAnalyzer.analyze_alert()
+    │
+    ├─► AIBClient.enrich_alert()
+    │       │
+    │       ├─ container.name + namespace → k8s:pod:<ns>/<name>
+    │       │   └─ fallback: host.hostname → vm:host:<hostname>
+    │       │                              → k8s:node:<hostname>
+    │       │
+    │       ├─ GET /api/v1/graph/nodes/{node_id}        → asset metadata
+    │       ├─ GET /api/v1/impact/{node_id}              → blast radius
+    │       └─ GET /api/v1/graph/analysis/audit?node_id= → audit findings
+    │
+    ├─► Obfuscator (IPs, usernames, paths → tokens)
+    │
+    ├─► LLM prompt (alert + AIB context section)
+    │
+    └─► Analysis result (with aib_context field)
+```
+
+## Node ID Format
+
+AIB uses a `source:type:identifier` format for node IDs:
+
+| Asset type | Node ID format | Falco fields used |
+|------------|---------------|-------------------|
+| Kubernetes pod | `k8s:pod:<namespace>/<pod-name>` | `container.name` + `kubernetes.namespace.name` |
+| VM / bare-metal host | `vm:host:<hostname>` | `host.hostname` |
+| Kubernetes node | `k8s:node:<nodename>` | `host.hostname` (fallback) |
+
+The bridge tries K8s pod first. If the container name is empty, `host`, or `<NA>`, it falls back to hostname-based lookups.
+
+## Configuration
+
+### 1. Set environment variables
+
+In your `.env` file:
+
+```bash
+AIB_BASE_URL=http://aib:8080       # AIB API endpoint (Docker service name or IP)
+AIB_API_TOKEN=your-aib-api-token   # Optional — omit if AIB has no auth
+```
+
+### 2. Verify `config.yaml`
+
+The `aib` block is already present after `make install-analysis`:
+
+```yaml
+aib:
+  url: ${AIB_BASE_URL:-}       # leave empty to disable
+  api_token: ${AIB_API_TOKEN:-}
+  cache_ttl: 300               # seconds — AIB responses are cached per node
+```
+
+### 3. Restart the analysis service
+
+```bash
+make restart-analysis
+```
+
+### Disabling AIB
+
+Leave `AIB_BASE_URL` empty (or unset). The integration is fully opt-in — if the URL is not configured, no enrichment is attempted and no errors are raised.
+
+## Graceful Degradation
+
+AIB enrichment is best-effort at every step:
+
+- **AIB URL not set** → enrichment skipped, alert analyzed normally
+- **AIB unreachable** → exception caught, empty context, analysis proceeds
+- **Node not found in AIB (404)** → null context returned, analysis proceeds
+- **Partial data** (node found, blast radius unavailable) → whatever is available is included
+
+The LLM prompt is constructed only from the fields that are actually populated. A missing blast radius or missing audit findings simply means that section is omitted from the prompt.
+
+## Example Enriched Analysis
+
+Given a Falco alert:
+```
+Read sensitive file untrusted: user=appuser file=/etc/shadow
+container=payment-api namespace=production host=k8s-node-3
+```
+
+The AIB bridge resolves `k8s:pod:production/payment-api` and fetches:
+
+```
+Asset Context (AIB graph):
+- Asset ID: k8s:pod:production/payment-api
+- Environment: production
+- Team: payments
+- Criticality: critical
+- Owner: payments-eng@company.com
+- Blast radius: 8 downstream assets
+  - k8s:pod:production/fraud-detection
+  - k8s:pod:production/billing-service
+  - k8s:pod:production/audit-logger
+- Pre-existing audit findings (2):
+  - Container running as root (CIS 5.4.1)
+  - Privileged port binding enabled
+```
+
+The LLM now answers with awareness of criticality and blast radius:
+
+```
+Risk Assessment: CRITICAL
+The affected service (payment-api) is classified as critical infrastructure
+in the payments team. Compromise of this pod provides a foothold into 8
+downstream services including fraud detection and billing. Combined with
+the pre-existing finding that this container runs as root, the attacker
+likely already has unrestricted access to the container filesystem.
+
+Immediate actions:
+1. Isolate payment-api pod — network policy to deny egress immediately
+2. The audit finding "container running as root" amplifies this alert's
+   severity — /etc/shadow is accessible without privilege escalation
+3. Notify payments-eng team lead — this is a production critical-path service
+```
+
+Compare to the same alert without AIB enrichment, where the LLM would give generic advice with no knowledge of production impact.
+
+## API Response
+
+The `/api/analyze` JSON response includes an `aib_context` field:
+
+```json
+{
+  "rule": "Read sensitive file untrusted",
+  "analysis": "...",
+  "aib_context": {
+    "node_id": "k8s:pod:production/payment-api",
+    "node": {
+      "id": "k8s:pod:production/payment-api",
+      "metadata": {
+        "environment": "production",
+        "team": "payments",
+        "criticality": "critical"
+      }
+    },
+    "blast_radius": {
+      "affected_nodes": [...]
+    },
+    "audit_findings": [
+      { "title": "Container running as root", "severity": "high" }
+    ]
+  }
+}
+```
+
+`aib_context` is `{}` when AIB is not configured or the asset wasn't found.
+
+## Caching
+
+AIB responses are cached in memory per `cache_ttl` seconds (default: 300s / 5 minutes). This means:
+
+- Repeated alerts from the same pod/host reuse the cached node metadata
+- Blast radius and audit findings are not re-fetched on every alert
+- Cache is per-process — restarts clear it
+
+For high-volume environments, increase `cache_ttl` to reduce AIB API load. For incident response where asset state is changing rapidly, set it lower or restart the analysis service to force a refresh.


### PR DESCRIPTION
Adds an optional AIB (Assets in a Box) integration that enriches Falco security alerts with asset metadata, blast radius, and audit findings before passing them to the LLM for analysis.

- analysis/aib_bridge.py: new AIBClient with TTL caching; maps Falco container.name+namespace → k8s:pod node IDs, falls back to host.hostname → vm:host nodes; format_aib_context() renders context as prompt section
- analysis/analyzer.py: AlertAnalyzer._create_aib_client() reads config/env; analyze_alert() enriches prompt with AIB context, includes aib_context in result dict; fully graceful — alert analyzed normally if AIB unreachable
- analysis/api.py: /api/analyze returns aib_context in JSON; /analyze and /history/<key> HTML pages render an "Asset Context" card when AIB node found; aib_context stored in cache for subsequent page loads
- analysis/config.yaml: aib.url / aib.api_token / aib.cache_ttl section
- .env.example: AIB_BASE_URL and AIB_API_TOKEN documented