### PR TITLE
fix(aib-bridge): align with AIB API response shapes

### DIFF
--- a/analysis/aib_bridge.py
+++ b/analysis/aib_bridge.py
@@ -8,11 +8,14 @@ Asset node ID format: source:type:identifier
   - k8s:pod:namespace/name
   - k8s:node:nodename
   - vm:host:hostname
+  - ansible:vm:hostname
+  - tf:vm:hostname
 """
 
 import time
 import logging
 import requests
+from urllib.parse import quote
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -67,20 +70,31 @@ class AIBClient:
         return self._get(f"/api/v1/impact/{node_id}")
 
     def get_audit_findings(self, node_id: str) -> list:
-        data = self._get(f"/api/v1/graph/analysis/audit?node_id={node_id}")
+        data = self._get(f"/api/v1/graph/analysis/audit?node_id={quote(node_id, safe='')}")
         if isinstance(data, list):
             return data
         if isinstance(data, dict):
             return data.get('findings') or data.get('results') or []
         return []
 
+    def resolve_node(self, hostname: str) -> Optional[dict]:
+        """Find a node by hostname, regardless of IaC source prefix.
+
+        Calls GET /api/v1/graph/nodes/resolve?hostname=<hostname>, which
+        matches any node whose ID ends with :<hostname> — covering
+        k8s:node:, ansible:vm:, tf:vm:, etc.
+        """
+        return self._get(f"/api/v1/graph/nodes/resolve?hostname={quote(hostname, safe='')}")
+
     def enrich_alert(self, alert: dict) -> dict:
         """
         Derive AIB context from Falco alert fields.
 
         Tries k8s pod lookup first (container.name + namespace), then VM/host
-        lookup (host.hostname). All lookups are best-effort — returns an empty
-        context dict if the asset isn't in AIB or AIB is unreachable.
+        lookup (host.hostname). Falls back to the /resolve endpoint which
+        matches any source prefix (ansible:vm:, tf:vm:, k8s:node:, etc.).
+        All lookups are best-effort — returns an empty context dict if the
+        asset isn't in AIB or AIB is unreachable.
 
         Returns:
             {
@@ -115,11 +129,19 @@ class AIBClient:
             node = self.get_node(node_id)
 
         if node is None and hostname:
-            for candidate in (f"vm:host:{hostname}", f"k8s:node:{hostname}"):
+            # Try well-known exact-prefix formats first
+            for candidate in (f"k8s:node:{hostname}", f"vm:host:{hostname}"):
                 node = self.get_node(candidate)
                 if node:
                     node_id = candidate
                     break
+
+            # Fallback: resolve endpoint matches ansible:vm:, tf:vm:, etc.
+            if node is None:
+                resolved = self.resolve_node(hostname)
+                if resolved:
+                    node = resolved
+                    node_id = resolved.get('id', f"unknown:vm:{hostname}")
 
         blast_radius = None
         audit_findings: list = []
@@ -152,29 +174,38 @@ def format_aib_context(ctx: dict) -> str:
     lines = ['\n\n**Asset Context (AIB graph):**']
     lines.append(f'- Asset ID: `{node_id}`')
 
-    # Surface any structured metadata the AIB node carries
-    meta = node.get('metadata') or node.get('properties') or node.get('labels') or {}
+    # Surface any structured metadata the AIB node carries.
+    # AIB may store Kubernetes labels as "label:key" — strip the prefix.
+    raw_meta = node.get('metadata') or node.get('properties') or node.get('labels') or {}
+    meta = {k.removeprefix('label:'): v for k, v in raw_meta.items()}
     for key in ('environment', 'team', 'criticality', 'owner', 'service'):
         val = meta.get(key)
         if val:
             lines.append(f'- {key.title()}: {val}')
 
-    # Blast radius
+    # Blast radius.
+    # AIB returns: affected_nodes (int count) + nodes (flat list, added in feat/sib-integration)
+    # Older AIB: impact_tree (keyed map). Handle all three.
     br = ctx.get('blast_radius')
     if br:
-        affected = br.get('affected_nodes') or br.get('nodes') or []
-        if affected:
-            lines.append(f'- Blast radius: {len(affected)} downstream assets')
-            for n in affected[:3]:
-                nid = n.get('id') or n.get('node_id') or str(n)
+        node_list = br.get('nodes') or list(br.get('impact_tree', {}).values())
+        count = br.get('affected_nodes', len(node_list))
+        if count or node_list:
+            lines.append(f'- Blast radius: {count} downstream assets')
+            for n in node_list[:3]:
+                nid = n.get('node_id') or n.get('id') or str(n)
                 lines.append(f'  - {nid}')
 
-    # Pre-existing audit findings
+    # Pre-existing audit findings.
     findings = ctx.get('audit_findings') or []
     if findings:
         lines.append(f'- Pre-existing audit findings ({len(findings)}):')
         for f in findings:
-            title = f.get('title') or f.get('finding') or f.get('message') or str(f) if isinstance(f, dict) else str(f)
+            if isinstance(f, dict):
+                title = (f.get('title') or f.get('description')
+                         or f.get('finding') or f.get('message') or str(f))
+            else:
+                title = str(f)
             lines.append(f'  - {title}')
 
     return '\n'.join(lines)


### PR DESCRIPTION
Three fixes for actual AIB response format:

1. Blast radius: AIB returns affected_nodes as int + nodes as flat list (or impact_tree as keyed map on older versions). Format context now handles all three rather than trying len() on an int.

2. Finding title: add description to fallback chain before str(f) so audit findings render as human-readable text not dict repr.

3. Hostname resolution: after k8s:node: and vm:host: prefix lookups, fall back to GET /api/v1/graph/nodes/resolve?hostname= which matches any source prefix (ansible:vm:, tf:vm:, etc.).

Also URL-encodes node_id and hostname in query params, and strips label: prefix from Kubernetes metadata keys when surfacing team/owner.